### PR TITLE
Fix yank (might be version-specific)

### DIFF
--- a/lua/yaml_nvim/init.lua
+++ b/lua/yaml_nvim/init.lua
@@ -24,11 +24,7 @@ end
 local assure_yaml_filetype = function(func, ...)
 	local restore_to = set_yaml_as_filetype()
 
-	if arg == nil then
-		func()
-	else
-		func(unpack(arg))
-	end
+	func(...)
 
 	restore_filetype(restore_to)
 end

--- a/lua/yaml_nvim/init.lua
+++ b/lua/yaml_nvim/init.lua
@@ -66,7 +66,7 @@ local yank = function(key, value, register)
 		contents = parsed.cleaned_value
 	end
 
-	contents = string.gsub(contents, "'", "\\'")
+	contents = string.gsub(contents, "'", "''")
 	vim.cmd(string.format("call setreg('%s', '%s')", register, contents))
 end
 


### PR DESCRIPTION
Hi, love the idea for this plugin.

I just couldn't get the yank feature to work, so I started digging into it.
I had to apply these two fixes: use of `arg` and escaping single quote.

I don't get how this works for anyone else - it might be version-specific?

Feel free to close this if you don't think it is applicable.