### PR TITLE
Add safety to get_value, is_sequence_block on nil values

### DIFF
--- a/lua/yaml_nvim/pair.lua
+++ b/lua/yaml_nvim/pair.lua
@@ -28,21 +28,26 @@ end
 local function get_value(node, bufnr)
 	while node ~= nil do
 		if node:type() == "block_mapping_pair" then
-			local value = node:field("value")[1]
-			return table.concat({ vim.treesitter.get_node_text(value, bufnr) }, "\n")
+			if node:field("value")[1] ~= nil then
+				local value = node:field("value")[1]
+				return table.concat({ vim.treesitter.get_node_text(value, bufnr) }, "\n")
+			end
 		end
-
 		node = node:parent()
 	end
 end
 
 local function is_sequence_block(value)
-	if value:type() ~= "block_node" then
-		return false
-	end
+	if value then
+		if value:type() ~= "block_node" then
+			return false
+		end
 
-	for block_sequence, _ in value:iter_children() do
-		return block_sequence:type() == "block_sequence"
+		for block_sequence, _ in value:iter_children() do
+			return block_sequence:type() == "block_sequence"
+		end
+	else
+		return false
 	end
 end
 


### PR DESCRIPTION
Support for returning an empty value instead of crashing when the value is nil

This helps when working on in-progress yaml files while the winbar is activated and you are browsing across multiple keys. 

![image](https://github.com/cuducos/yaml.nvim/assets/36175703/9ea94e40-6190-4c80-bada-e97b8bce53aa)

![image](https://github.com/cuducos/yaml.nvim/assets/36175703/9dbec9bb-a7b7-4080-8106-fbd1809c749f)


Results in `port:` just having an empty value instead of a stack trace.


