### PR TITLE
fix pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ require("yaml_nvim").setup({ ft = { "yaml",  "other yaml filetype" } })
 
 ```lua
 vim.api.nvim_create_autocmd({ "BufEnter", "CursorMoved" }, {
-	pattern = { "yaml" },
+	pattern = { "*.yaml" },
 	callback = function()
 		vim.opt_local.winbar = require("yaml_nvim").get_yaml_key_and_value()
 	end,


### PR DESCRIPTION
https://neovim.io/doc/user/lua-guide.html#lua-guide-autocommand-create

`pattern = { "yaml" },` didn't work for me; needed `pattern = { "*.yaml" },`