### PR TITLE
fix: nil check on clean_up_block_value

### DIFF
--- a/lua/yaml_nvim/pair.lua
+++ b/lua/yaml_nvim/pair.lua
@@ -16,6 +16,9 @@ local function reverse(keys)
 end
 
 local function clean_up_block_value(value)
+	if value == nil then
+		return
+	end
 	value = string.gsub(value, "\n", " ")
 
 	if value:sub(1, 1) ~= "|" then


### PR DESCRIPTION
While editing you could create

```yaml

something:

```

and as soon as you hit `:` it would hit `nil` at clean_up_block_value and throw an exception
![image](https://github.com/user-attachments/assets/5114b775-d39a-4731-8b23-e258dd63c2fe)

Using
```lua
vim.api.nvim_create_autocmd({ "FileType" }, {
	pattern = { "yaml", "yaml.ansible"  },
	callback = function()
  	vim.opt_local.winbar = "%{%v:lua.require'yaml_nvim'.get_yaml_key()%}"
	end,
})
```
