### PR TITLE
no-name buffer winbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,14 @@ require("yaml_nvim").setup({ ft = { "yaml",  "other yaml filetype" } })
 #### Neovim's winbar
 
 ```lua
-vim.api.nvim_create_autocmd({ "BufEnter", "CursorMoved" }, {
-  pattern = { "*.yaml" },
+vim.api.nvim_create_autocmd({ "FileType" }, {
+  pattern = { "yaml" },
   callback = function()
-    vim.opt_local.winbar = require("yaml_nvim").get_yaml_key_and_value()
+    vim.api.nvim_create_autocmd({ "CursorMoved" }, {
+      callback = function()
+        vim.opt_local.winbar = "." .. (require("yaml_nvim").get_yaml_key() or "")
+      end,
+    })
   end,
 })
 ```

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ vim.api.nvim_create_autocmd({ "FileType" }, {
   callback = function()
     vim.api.nvim_create_autocmd({ "CursorMoved" }, {
       callback = function()
-        vim.opt_local.winbar = "." .. (require("yaml_nvim").get_yaml_key() or "")
+        vim.opt_local.winbar = require("yaml_nvim").get_yaml_key()
       end,
     })
   end,


### PR DESCRIPTION
It's nice to have a winbar for no-name buffers, such as when you pipe stdout to nvim like `kubectl get pod worker-0 -o yaml | nvim -c "set ft=yaml"`