### PR TITLE
Fix a bug caused by usage of global value

### DIFF
--- a/lua/yaml_nvim/init.lua
+++ b/lua/yaml_nvim/init.lua
@@ -76,7 +76,7 @@ end
 
 -- Public API
 
-M = {}
+local M = {}
 
 M.default_config = {
 	ft = { "yaml", "eruby.yaml" },

--- a/lua/yaml_nvim/init.lua
+++ b/lua/yaml_nvim/init.lua
@@ -2,6 +2,8 @@ local has_telescope, _ = pcall(require, "telescope")
 local document = require("yaml_nvim.document")
 local pair = require("yaml_nvim.pair")
 
+local M = {}
+
 local is_yaml = function()
 	local curr = vim.bo.filetype
 	for _, ft in ipairs(M.config.ft) do
@@ -75,8 +77,6 @@ local yank = function(node, key, value, register)
 end
 
 -- Public API
-
-local M = {}
 
 M.default_config = {
 	ft = { "yaml", "eruby.yaml" },


### PR DESCRIPTION
Actually this plugin is conflicted with another plugin `nkakouros-original/numbers.nvim` that is also using a global 'M'