### PR TITLE
fixing syntax error for packer-config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ use {
   ft = { "yaml" }, -- optional
   requires = {
     "folke/snacks.nvim", -- optional
-    "nvim-telescope/telescope.nvim" -- optional
-    "ibhagwan/fzf-lua" --optional
+    "nvim-telescope/telescope.nvim", -- optional
+    "ibhagwan/fzf-lua", -- optional
   },
 }
 ```


### PR DESCRIPTION
Copy/pasting this snippet leads to error: 
```
E5107: Error loading lua [string ":source buffer=1"]:89: '}' expected (to close '{' at line 86) near '"ibhagwan/fzf-lua"'
```